### PR TITLE
ci(coverage): exclude QML smoke tests from gcov coverage run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,9 +190,13 @@ jobs:
             -DAJAZZ_ENABLE_WERROR=OFF
 
       - name: Build & test
+        # -LE qml: the QML smoke tests instantiate a real QQmlEngine, which
+        # SIGSEGVs under gcov coverage instrumentation (gcov x Qt-QML) while
+        # passing in every normal build. They contribute no logic coverage,
+        # so exclude them here; the release build matrix still runs them.
         run: |
           cmake --build build-cov
-          ctest --test-dir build-cov --output-on-failure
+          ctest --test-dir build-cov --output-on-failure --label-exclude qml
 
       - name: Generate report
         run: |

--- a/tests/qml/CMakeLists.txt
+++ b/tests/qml/CMakeLists.txt
@@ -170,4 +170,10 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     endif()
 endif()
 
-catch_discover_tests(ajazz_qml_tests PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+# LABELS "qml" lets the coverage CI job exclude these via `ctest -LE qml`. They instantiate QML
+# through a real QQmlEngine, which SIGSEGVs under gcov coverage instrumentation (gcov x Qt-QML
+# interaction) while passing in every normal build. They add no logic coverage, so the coverage job
+# skips them and the release build matrix keeps them as the real smoke gate.
+catch_discover_tests(
+    ajazz_qml_tests PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen" LABELS "qml"
+)


### PR DESCRIPTION
-