### PR TITLE
fix(packaging): bundle the Qt runtime in the Windows MSI/ZIP + CI guard

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -84,6 +84,33 @@ jobs:
         run: |
           cpack -G WIX
           cpack -G ZIP
+      - name: Verify Qt runtime bundled in package
+        working-directory: build/windows-release
+        shell: pwsh
+        # Guard against the v0.1.0 regression: cpack -G WIX/ZIP succeeds even when the install
+        # tree is missing every Qt DLL, shipping a package that fails at launch with
+        # "Qt6Widgets.dll was not found". Unzip the built ZIP (same install tree the MSI
+        # harvests) and assert the Qt runtime is actually present: the core widget DLL plus the
+        # windows platform plugin (without qwindows.dll the app aborts with "no Qt platform
+        # plugin could be initialized").
+        run: |
+          $zip = Get-ChildItem *.zip | Select-Object -First 1
+          if (-not $zip) { throw "No ZIP produced — cannot verify Qt runtime" }
+          $dest = Join-Path $env:RUNNER_TEMP "acc-pkg-verify"
+          if (Test-Path $dest) { Remove-Item -Recurse -Force $dest }
+          Expand-Archive -Path $zip.FullName -DestinationPath $dest
+          $required = @("Qt6Widgets.dll", "qwindows.dll")
+          $missing = @()
+          foreach ($f in $required) {
+            if (-not (Get-ChildItem -Recurse -Path $dest -Filter $f)) { $missing += $f }
+          }
+          if ($missing.Count -gt 0) {
+            Write-Host "::group::package contents"
+            Get-ChildItem -Recurse -Path $dest | ForEach-Object { Write-Host $_.FullName }
+            Write-Host "::endgroup::"
+            throw "Qt runtime missing from Windows package: $($missing -join ', '). windeployqt did not populate the install tree."
+          }
+          Write-Host "OK: Qt runtime bundled ($($required -join ', '))"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: nightly-windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,35 @@ jobs:
           cpack -G ZIP
           if ($LASTEXITCODE -ne 0) { throw "ZIP packaging failed" }
 
+      - name: Verify Qt runtime bundled in package
+        working-directory: build/windows-release
+        shell: pwsh
+        # Guard against the v0.1.0 regression: cpack -G WIX/ZIP succeeds even when the install
+        # tree is missing every Qt DLL, shipping an MSI that fails at launch with
+        # "Qt6Widgets.dll was not found". Unzip the built ZIP (same install tree the MSI
+        # harvests) and assert the Qt runtime is actually present: the core widget DLL plus the
+        # windows platform plugin (without qwindows.dll the app aborts with "no Qt platform
+        # plugin could be initialized"). Runs before code-signing so a broken package fails the
+        # release job loudly instead of publishing an unrunnable installer.
+        run: |
+          $zip = Get-ChildItem *.zip | Select-Object -First 1
+          if (-not $zip) { throw "No ZIP produced — cannot verify Qt runtime" }
+          $dest = Join-Path $env:RUNNER_TEMP "acc-pkg-verify"
+          if (Test-Path $dest) { Remove-Item -Recurse -Force $dest }
+          Expand-Archive -Path $zip.FullName -DestinationPath $dest
+          $required = @("Qt6Widgets.dll", "qwindows.dll")
+          $missing = @()
+          foreach ($f in $required) {
+            if (-not (Get-ChildItem -Recurse -Path $dest -Filter $f)) { $missing += $f }
+          }
+          if ($missing.Count -gt 0) {
+            Write-Host "::group::package contents"
+            Get-ChildItem -Recurse -Path $dest | ForEach-Object { Write-Host $_.FullName }
+            Write-Host "::endgroup::"
+            throw "Qt runtime missing from Windows package: $($missing -join ', '). windeployqt did not populate the install tree."
+          }
+          Write-Host "OK: Qt runtime bundled ($($required -join ', '))"
+
       - name: Code-sign MSI
         if: env.WIN_CERT_BASE64 != ''
         shell: pwsh

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -507,6 +507,22 @@ endif()
 
 install(TARGETS ajazz-control-center RUNTIME DESTINATION bin BUNDLE DESTINATION .)
 
+# Windows: bundle the Qt runtime into the install tree so the CPack WIX MSI and ZIP (which harvest
+# the whole install tree) are self-contained. Without this the package ships ONLY
+# ajazz-control-center.exe and the installed app fails to start with "The code execution cannot
+# proceed because Qt6Widgets.dll was not found" (Qt6Widgets is pulled in by QApplication in main.cpp
+# + QSystemTrayIcon in tray_controller.cpp). qt_generate_deploy_qml_app_script runs windeployqt (Qt
+# libs + platform/style/imageformat/tls plugins + the QML module imports) at `cmake --install` time,
+# populating bin/ before CPack harvests it. NOTE: validated by the windows-2022 MSI job — cannot be
+# exercised on Linux.
+if(WIN32)
+    qt_generate_deploy_qml_app_script(
+        TARGET ajazz-control-center OUTPUT_SCRIPT _ajazz_deploy_script
+        NO_UNSUPPORTED_PLATFORM_ERROR NO_TRANSLATIONS
+    )
+    install(SCRIPT "${_ajazz_deploy_script}")
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     install(FILES ${CMAKE_SOURCE_DIR}/resources/linux/ajazz-control-center.desktop
             DESTINATION share/applications


### PR DESCRIPTION
## Why

The published **v0.1.0 Windows MSI** ships only `ajazz-control-center.exe` + `hidapi.pc` — **no Qt runtime**. The installed app fails to launch with *"The code execution cannot proceed because Qt6Widgets.dll was not found."* This is what blocked the winget submission ([microsoft/winget-pkgs#378692](https://github.com/microsoft/winget-pkgs/pull/378692)) during manual validation.

Verified by extracting the live `v0.1.0` and the latest `nightly` MSI — both contain the same 2 files, zero Qt DLLs. The deploy fix (`1aa606c`) existed on a feature branch but never reached `develop`/`main`/any tag, so every released/nightly MSI was still broken.

## What

1. **`fix(packaging)`** (cherry-pick of `1aa606c`) — WIN32-gated `qt_generate_deploy_qml_app_script` + `install(SCRIPT)` so `windeployqt` populates `bin/` (Qt libs, platform/style/imageformat/tls plugins, QML imports) at install time, before CPack harvests the tree. Both the MSI and the portable ZIP are built from that tree, so both are fixed.

2. **`ci(packaging)`** — post-package guard in `release.yml` + `nightly.yml`: unzip the built ZIP and assert `Qt6Widgets.dll` **and** `qwindows.dll` are present, failing the job loudly otherwise. `cpack` succeeds even on an empty install tree, so without this guard a regression silently ships an unrunnable installer again. In `release.yml` it runs before code-signing.

## Verification

- Linux configure clean; the deploy path is Windows-only and is proven by the new guard on the `windows-2022` job (this PR's CI / a `nightly` workflow_dispatch on this branch).
- Follow-up after merge: promote `develop`→`main`, tag `v0.1.1`, then update the winget PR's `InstallerUrl`+`Sha256` to the fixed MSI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)